### PR TITLE
chore: update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,16 @@
     }
   ],
   "require": {
-    "symfony/http-client": "~4.0",
+    "php": ">=8.0",
+    "symfony/http-client": "~5.0|~6.0",
     "psr/log": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.0",
-    "squizlabs/php_codesniffer": "~2.0",
-    "symfony/var-dumper": "~4.0",
-    "php-coveralls/php-coveralls": "2.1",
-    "phpstan/phpstan": "~0.11.5"
+    "phpunit/phpunit": "^9.5",
+    "squizlabs/php_codesniffer": "~3.7",
+    "symfony/var-dumper": "~5.0|~6.0",
+    "php-coveralls/php-coveralls": "^2.5",
+    "phpstan/phpstan": "^1.8"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
   ],
   "require": {
     "php": ">=8.0",
-    "symfony/http-client": "~5.0|~6.0",
+    "symfony/http-client": "~5.0",
     "psr/log": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
     "squizlabs/php_codesniffer": "~3.7",
-    "symfony/var-dumper": "~5.0|~6.0",
+    "symfony/var-dumper": "~5.0",
     "php-coveralls/php-coveralls": "^2.5",
     "phpstan/phpstan": "^1.8"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,14 +15,14 @@
          stopOnFailure="false"
          verbose="true"
 >
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/FunnelHttpClient.php
+++ b/src/FunnelHttpClient.php
@@ -14,42 +14,12 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 final class FunnelHttpClient implements HttpClientInterface
 {
-    /**
-     * @var HttpClientInterface
-     */
-    private $decorated;
-
-    /**
-     * @var ThrottleStorageInterface
-     */
-    private $throttleStorage;
-
-    /**
-     * @var ThrottleStrategyInterface|null
-     */
-    private $throttleStrategy;
-
-    /**
-     * @var LoggerInterface|null
-     */
-    private $logger;
-
-    /**
-     * FunnelHttpClient constructor.
-     *
-     * @param HttpClientInterface            $decorated
-     * @param ThrottleStorageInterface       $throttleStorage
-     * @param ThrottleStrategyInterface|null $throttleStrategy
-     * @param LoggerInterface|null           $logger
-     */
     public function __construct(
-        HttpClientInterface $decorated,
-        ThrottleStorageInterface $throttleStorage,
-        ?ThrottleStrategyInterface $throttleStrategy = null,
-        ?LoggerInterface $logger = null
+        private HttpClientInterface $decorated,
+        private ThrottleStorageInterface $throttleStorage,
+        private ?ThrottleStrategyInterface $throttleStrategy = null,
+        private ?LoggerInterface $logger = null
     ) {
-        $this->decorated = $decorated;
-        $this->throttleStorage = $throttleStorage;
         $this->throttleStrategy = $throttleStrategy ?? new AlwaysThrottleStrategy();
         $this->logger = $logger ?? new NullLogger();
     }
@@ -106,5 +76,16 @@ final class FunnelHttpClient implements HttpClientInterface
     public static function throttle(HttpClientInterface $client, int $maxRequests, float $timeWindow, ?LoggerInterface $logger = null): self
     {
         return new self($client, new ArrayStorage($maxRequests, $timeWindow), null, $logger);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->client = $this->decorated->withOptions($options);
+
+        return $clone;
     }
 }

--- a/src/FunnelHttpClient.php
+++ b/src/FunnelHttpClient.php
@@ -77,15 +77,4 @@ final class FunnelHttpClient implements HttpClientInterface
     {
         return new self($client, new ArrayStorage($maxRequests, $timeWindow), null, $logger);
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function withOptions(array $options): static
-    {
-        $clone = clone $this;
-        $clone->client = $this->decorated->withOptions($options);
-
-        return $clone;
-    }
 }

--- a/src/Storage/ArrayStorage.php
+++ b/src/Storage/ArrayStorage.php
@@ -4,33 +4,14 @@ namespace BenTools\FunnelHttpClient\Storage;
 
 final class ArrayStorage implements ThrottleStorageInterface
 {
-    /**
-     * @var int
-     */
-    private $maxRequests;
+    private int $currentRequests = 0;
 
-    /**
-     * @var float
-     */
-    private $timeWindow;
+    private float|null $startedAt = null;
 
-    /**
-     * @var int
-     */
-    private $currentRequests = 0;
-
-    /**
-     * @var float|null
-     */
-    private $startedAt;
-
-    /**
-     * ArrayStorage constructor.
-     */
-    public function __construct(int $maxRequests, float $timeWindow)
-    {
-        $this->maxRequests = $maxRequests;
-        $this->timeWindow = $timeWindow;
+    public function __construct(
+        private int $maxRequests,
+        private float $timeWindow
+    ) {
     }
 
     /**
@@ -69,18 +50,12 @@ final class ArrayStorage implements ThrottleStorageInterface
         $this->currentRequests++;
     }
 
-    /**
-     *
-     */
     private function reset()
     {
         $this->currentRequests = 0;
         $this->startedAt = null;
     }
 
-    /**
-     * @return bool
-     */
     private function isExpired(): bool
     {
         if (null === $this->startedAt) {


### PR DESCRIPTION
Add PHP8 requirement and update dependencies.

I don't add Symfony 6 compatibility because I don't know how to manage `HttpClientInterface::withOptions` defined only on it.