### PR TITLE
Feat: Increment before request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "symfony/http-client": "~5.0|~6.0",
+    "symfony/http-client": "~5.0|~6.0|^7.0",
     "psr/log": "^1|^2|^3"
   },
   "require-dev": {

--- a/src/Storage/ArrayStorage.php
+++ b/src/Storage/ArrayStorage.php
@@ -50,7 +50,16 @@ final class ArrayStorage implements ThrottleStorageInterface
         $this->currentRequests++;
     }
 
-    private function reset()
+    public function decrement(): void
+    {
+        $this->currentRequests--;
+        if ($this->currentRequests <= 0) {
+            $this->reset();
+        }
+    }
+
+
+    private function reset(): void
     {
         $this->currentRequests = 0;
         $this->startedAt = null;

--- a/src/Storage/ThrottleStorageInterface.php
+++ b/src/Storage/ThrottleStorageInterface.php
@@ -22,4 +22,9 @@ interface ThrottleStorageInterface
      * Add a call to the current time window.
      */
     public function increment(): void;
+
+    /**
+     * Remove a call from the current time window.
+     */
+    public function decrement(): void;
 }


### PR DESCRIPTION
Feat: increment counter before executing the request, to avoid multiple concurrent calls on slow API endpoints.
In case of a transport exception, cancel increment.