### PR TITLE
chore: remove PHP deprecation

### DIFF
--- a/src/FunnelHttpClient.php
+++ b/src/FunnelHttpClient.php
@@ -68,7 +68,7 @@ final class FunnelHttpClient implements HttpClientInterface
     /**
      * @inheritDoc
      */
-    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
         return $this->decorated->stream($responses, $timeout);
     }


### PR DESCRIPTION
To remove this deprecation introduced in PHP `8.4`:
```
  BenTools\FunnelHttpClient\FunnelHttpClient::stream(): Implicitly marking parameter $timeout as nullable is deprecated, the explicit nullable type must be used instead
```